### PR TITLE
Support Custom Field Definition Retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The following entity types are currently supported for list:
 * Pipeline
 * Pipeline Stage
 * Webhook
+* CustomFieldDefinition
 
 The response will either be an instance of `ProsperWorks::Errors`, or the entity itself. See the `handle_response` function in [connect.rb](lib/prosperworks/api_operations/connect.rb).
 

--- a/lib/prosperworks.rb
+++ b/lib/prosperworks.rb
@@ -33,6 +33,7 @@ require 'prosperworks/project'
 require 'prosperworks/task'
 require 'prosperworks/version'
 require 'prosperworks/webhook'
+require 'prosperworks/custom_field_definition'
 
 module ProsperWorks
 

--- a/lib/prosperworks/base_entity.rb
+++ b/lib/prosperworks/base_entity.rb
@@ -4,18 +4,44 @@ module ProsperWorks
     # used for the 6 main entity types
 
     attr_accessor :assignee_id,
-                  :custom_fields,
                   :date_modified,
                   :details,
                   :name,
                   :tags
 
+    attr_writer   :custom_fields
 
     extend ApiOperations::Create
     extend ApiOperations::Delete
     extend ApiOperations::Find
     extend ApiOperations::Update
     extend ApiOperations::Search
-
+    
+    
+    def custom_fields
+      return @custom_fields unless @@custom_fields
+      @custom_field_values ||= @custom_fields.map do |field|
+        field_id = field["custom_field_definition_id"]
+        if @@custom_fields.include? field_id
+            custom = @@custom_fields[field_id]
+            if custom.options
+                option = custom.options.select{|o| o.id == field["value"]}.first
+                value = option&.name
+            else
+                value = field["value"]
+            end
+            { 
+              id => 
+                CustomFieldValue.new({ 
+                  field_name: custom.name,
+                  value: value,
+                  id: option&.id,
+                  data_type: custom.data_type
+                }) 
+            }
+        end
+      end.reduce(Hash.new, :merge)
+      
+    end
   end
 end

--- a/lib/prosperworks/custom_field_definition.rb
+++ b/lib/prosperworks/custom_field_definition.rb
@@ -1,11 +1,16 @@
 module ProsperWorks
-
+  class CustomFieldDefinitionOption < Base
+    attr_accessor :name,
+                  :rank
+  end
+  
   class CustomFieldDefinition < Base
+  
 
     attr_accessor :name,
                   :data_type,
-                  :available_on,
-                  :options
+                  :available_on
+    attr_writer   :options
                   
     def self.api_name
       "custom_field_definitions"
@@ -13,5 +18,12 @@ module ProsperWorks
 
     extend ApiOperations::Find
     extend ApiOperations::List
+    
+    def options
+      @custom_options ||= @options.map do |hash|
+        CustomFieldDefinitionOption.new(hash)
+      end unless @options.nil?
+    end
+    
   end
 end

--- a/lib/prosperworks/custom_field_definition.rb
+++ b/lib/prosperworks/custom_field_definition.rb
@@ -1,0 +1,17 @@
+module ProsperWorks
+
+  class CustomFieldDefinition < Base
+
+    attr_accessor :name,
+                  :data_type,
+                  :available_on,
+                  :options
+                  
+    def self.api_name
+      "custom_field_definitions"
+    end
+
+    extend ApiOperations::Find
+    extend ApiOperations::List
+  end
+end

--- a/lib/prosperworks/custom_field_definition.rb
+++ b/lib/prosperworks/custom_field_definition.rb
@@ -4,6 +4,12 @@ module ProsperWorks
                   :rank
   end
   
+  class CustomFieldValue < Base
+    attr_accessor :field_name,
+                  :value
+                  :data_type
+  end
+  
   class CustomFieldDefinition < Base
   
 

--- a/lib/prosperworks/utils.rb
+++ b/lib/prosperworks/utils.rb
@@ -18,5 +18,4 @@ module ProsperWorks
     end
 
   end
-
 end

--- a/test/prosperworks/integration/custom_field_definition_test.rb
+++ b/test/prosperworks/integration/custom_field_definition_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class CustomFieldDefinitionTest < Minitest::Test
+  include Helpers
+  
+  def verify_response(expected, actual)
+    assert actual.is_a?(ProsperWorks::CustomFieldDefinition)
+    assert_equal expected[:id], actual.id
+    assert_equal expected.keys.length, actual.instance_variables.length
+    
+    expected.each do|key, value|
+      next if value.is_a?(Enumerable)
+      if value.nil?
+        assert_nil actual.send(key)
+      else
+        assert_equal value, actual.send(key)
+      end
+    end
+  end
+  
+  def setup
+    @id = custom_field_definition_details[:id]
+    @single_resource_url = get_uri(ProsperWorks::CustomFieldDefinition.api_name, @id)
+    @list_url = get_uri(ProsperWorks::CustomFieldDefinition.api_name)
+  end
+  
+  def test_custom_field_definition_list
+    stub_request(:get, @list_url).with(headers: headers)
+                                 .to_return(status: 200, body: custom_field_definition_list_payload)
+    fields = ProsperWorks::CustomFieldDefinition.list
+    custom_field_definition_list_details.zip(fields).each do |expected, field|
+      verify_response(expected, field)
+    end
+  end
+  
+  def test_custom_field_definition_find
+    stub_request(:get, @single_resource_url).with(headers: headers)
+                                 .to_return(status: 200, body: custom_field_definition_payload)
+    field = ProsperWorks::CustomFieldDefinition.find(@id)
+    verify_response(custom_field_definition_details, field)
+  end
+end

--- a/test/prosperworks/integration/custom_field_definition_test.rb
+++ b/test/prosperworks/integration/custom_field_definition_test.rb
@@ -16,6 +16,21 @@ class CustomFieldDefinitionTest < Minitest::Test
         assert_equal value, actual.send(key)
       end
     end
+    
+    case expected[:options]
+    when nil
+      assert_nil actual.options
+    else
+      expected[:options].zip(actual.options).each do |defined,option|
+        defined.each do |key, value|
+          if value.nil?
+            assert_nil option.send(key)
+          else
+            assert_equal value, option.send(key)
+          end
+        end
+      end
+    end
   end
   
   def setup

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -351,5 +351,62 @@ module Helpers
       secret: { key_a: "value_a" }
     }
   end
-
+  
+  def custom_field_definition_list_payload
+    JSON.generate(custom_field_definition_list_details)
+  end
+  
+  def custom_field_definition_list_details
+    [
+      {
+        id: 1_007,
+        name: "Custom Dropdown Field",
+        data_type: "Dropdown",
+        available_on: ["company", "opportunity", "lead"],
+        options: [
+          {
+            id: 1_008,
+            name: "Option 1",
+            rank: 0
+          },
+          {
+            id: 1_009,
+            name: "Option 1",
+            rank: 0
+          }
+        ]
+      },
+      {
+        id: 1_010,
+        name: "Custom String Field",
+        data_type: "String",
+        available_on: ["company", "opportunity", "lead"]
+      }
+    ]
+  end
+  
+  def custom_field_definition_payload
+    JSON.generate(custom_field_definition_details)
+  end
+  
+  def custom_field_definition_details
+    {
+      id: 1_007,
+      name: "Custom Dropdown Field",
+      data_type: "Dropdown",
+      available_on: ["company", "opportunity", "lead"],
+      options: [
+        {
+          id: 1_008,
+          name: "Option 1",
+          rank: 0
+        },
+        {
+          id: 1_009,
+          name: "Option 1",
+          rank: 0
+        }
+      ]
+    }
+  end
 end


### PR DESCRIPTION
Addresses: #1 

- [x] Added `CustomFieldDefinition` resource
- [x] Added support for `list` and `find` operations on `CustomFieldDefinition`
- [x] Added tests for 
- [x] Support `CustomFieldDefinitionOption` on the `#options` method.