### PR TITLE
Fix Support for Error Handling In #list, #search, and #delete

### DIFF
--- a/lib/prosperworks/api_operations/connect.rb
+++ b/lib/prosperworks/api_operations/connect.rb
@@ -68,7 +68,7 @@ module ProsperWorks
 
       def handle_multiple_response(response)
         result = handle_response(nil, response)
-        if result.is_a?(ProsperWorks::Errors)
+        if result.is_a?(ProsperWorks::Errors::Base)
           # pass the error along
           result
         else

--- a/lib/prosperworks/api_operations/delete.rb
+++ b/lib/prosperworks/api_operations/delete.rb
@@ -15,7 +15,7 @@ module ProsperWorks
 
       def handle_delete_response(response)
         result = handle_response(nil, response)
-        if result.is_a?(ProsperWorks::Errors)
+        if result.is_a?(ProsperWorks::Errors::Base)
           # pass the error along
           result
         else

--- a/test/prosperworks/unit/api_operations/connect_test.rb
+++ b/test/prosperworks/unit/api_operations/connect_test.rb
@@ -65,5 +65,11 @@ class ConnectTest < Minitest::Test
 
     assert_equal Errors::Unprocessable, ProsperWorks::Contact.find(id)
   end
-
+  
+  def handle_multiple_response_error_handling
+    url = get_uri(ProsperWorks::Contact.api_name, 'search')
+    stub_request(:post, url).with(headers: headers).to_return(status: 500, body: "")
+    
+    assert_equal Errors::ServerError, ProsperWorks::Contact.search
+  end
 end


### PR DESCRIPTION
Previously, certain API operations threw exceptions when the ProsperWorks API server
returned errors when called. Now, errors returned from the API are passed along to the caller
to process, evaluate, and execute logic as needed.

Addresses #2 